### PR TITLE
creating "analog" files

### DIFF
--- a/code/masst_client.py
+++ b/code/masst_client.py
@@ -47,7 +47,7 @@ def process_matches(
     common_file = common_base_file_name(compound_name, file_name)
 
     # extract results
-    matches_df = masst.extract_matches_from_masst_results(
+    extracted_results = masst.extract_matches_from_masst_results(
         matches,
         precursor_mz_tol,
         min_matched_signals,
@@ -55,10 +55,30 @@ def process_matches(
         limit_to_best_match_in_file=True,
         add_dataset_titles=False,
     )
-    # always export match table even with 0 matches to mark that it was successful
-    masst_file = "{}_matches.tsv".format(common_file)
-    prepare_paths(file=masst_file)
-    matches_df[MATCH_COLUMNS].to_csv(masst_file, index=False, sep="\t")
+
+    if analog:
+        matches_df, analog_matches_df, original_matches_df = extracted_results
+        # Save analog results separately
+        analog_file = "{}_analog_matches.tsv".format(common_file)
+        prepare_paths(file=analog_file)
+        analog_matches_df[MATCH_COLUMNS + ["rounded_delta"]].to_csv(analog_file, index=False, sep="\t")
+
+        # Here we want to export the unfiltered results
+        masst_file = "{}_matches.tsv".format(common_file)
+        prepare_paths(file=masst_file)
+        matches_df[MATCH_COLUMNS].to_csv(masst_file, index=False, sep="\t")
+
+        # Here we want to export all FasstMASST results
+        original_masst_file = "{}_unfiltered_matches.tsv".format(common_file)
+        prepare_paths(file=original_masst_file)
+        original_matches_df[MATCH_COLUMNS].to_csv(original_masst_file, index=False, sep="\t")
+    else:
+        matches_df = extracted_results
+
+        # always export match table even with 0 matches to mark that it was successful
+        masst_file = "{}_matches.tsv".format(common_file)
+        prepare_paths(file=masst_file)
+        matches_df[MATCH_COLUMNS].to_csv(masst_file, index=False, sep="\t")
 
     lib_matches_df = masst.extract_matches_from_masst_results(
         library_matches, precursor_mz_tol, min_matched_signals, analog, False
@@ -92,6 +112,20 @@ def process_matches(
         compress_out_html=True,
     )
 
+    if analog:
+        logger.debug("Exporting microbeMASST analog %s", compound_name)
+        create_enriched_masst_tree(
+            analog_matches_df,
+            masst.MICROBE_MASST,
+            common_file=common_file + "_analog",
+            lib_match_json=lib_match_json,
+            input_str=input_label,
+            parameter_str=params_label,
+            usi=usi,
+            format_out_json=False,
+            compress_out_html=True,
+        )
+
     # plantMASST
     logger.debug("Exporting plantMASST %s", compound_name)
     create_enriched_masst_tree(
@@ -105,6 +139,20 @@ def process_matches(
         format_out_json=False,
         compress_out_html=True,
     )
+
+    if analog:
+        logger.debug("Exporting plantMASST analog %s", compound_name)
+        create_enriched_masst_tree(
+            analog_matches_df,
+            masst.PLANT_MASST,
+            common_file=common_file + "_analog",
+            lib_match_json=lib_match_json,
+            input_str=input_label,
+            parameter_str=params_label,
+            usi=usi,
+            format_out_json=False,
+            compress_out_html=True,
+        )
 
     # tissueMASST
     logger.debug("Exporting tissueMASST %s", compound_name)
@@ -120,6 +168,20 @@ def process_matches(
         compress_out_html=True,
     )
 
+    if analog:
+        logger.debug("Exporting tissueMASST analog %s", compound_name)
+        create_enriched_masst_tree(
+            analog_matches_df,
+            masst.TISSUE_MASST,
+            common_file=common_file + "_analog",
+            lib_match_json=lib_match_json,
+            input_str=input_label,
+            parameter_str=params_label,
+            usi=usi,
+            format_out_json=False,
+            compress_out_html=True,
+        )
+
     # foodMASST
     logger.debug("Exporting foodMASST %s", compound_name)
     create_enriched_masst_tree(
@@ -133,6 +195,20 @@ def process_matches(
         format_out_json=False,
         compress_out_html=True,
     )
+
+    if analog:
+        logger.debug("Exporting foodMASST analog %s", compound_name)
+        create_enriched_masst_tree(
+            analog_matches_df,
+            masst.FOOD_MASST,
+            common_file=common_file + "_analog",
+            lib_match_json=lib_match_json,
+            input_str=input_label,
+            parameter_str=params_label,
+            usi=usi,
+            format_out_json=False,
+            compress_out_html=True,
+        )
 
     # personalCareProductMASST
     logger.debug("Exporting personalCareProductMASST %s", compound_name)
@@ -148,6 +224,20 @@ def process_matches(
         compress_out_html=True,
     )
 
+    if analog:
+        logger.debug("Exporting personalCareProductMASST analog %s", compound_name)
+        create_enriched_masst_tree(
+            analog_matches_df,
+            masst.PERSONALCAREPRODUCT_MASST,
+            common_file=common_file + "_analog",
+            lib_match_json=lib_match_json,
+            input_str=input_label,
+            parameter_str=params_label,
+            usi=usi,
+            format_out_json=False,
+            compress_out_html=True,
+        )
+
     # microbiomeMASST
     logger.debug("Exporting microbiomeMASST %s", compound_name)
     create_enriched_masst_tree(
@@ -162,6 +252,20 @@ def process_matches(
         compress_out_html=True,
     )
 
+    if analog:
+        logger.debug("Exporting microbiomeMASST analog %s", compound_name)
+        create_enriched_masst_tree(
+            analog_matches_df,
+            masst.MICROBIOME_MASST,
+            common_file=common_file + "_analog",
+            lib_match_json=lib_match_json,
+            input_str=input_label,
+            parameter_str=params_label,
+            usi=usi,
+            format_out_json=False,
+            compress_out_html=True,
+        )
+
     # combined from all
     logger.debug("Exporting combined tree %s", compound_name)
     create_combined_masst_tree(
@@ -174,6 +278,19 @@ def process_matches(
         format_out_json=False,
         compress_out_html=True,
     )
+
+    if analog:
+        logger.debug("Exporting combined tree analog %s", compound_name)
+        create_combined_masst_tree(
+            analog_matches_df,
+            common_file=common_file + "_analog",
+            lib_match_json=lib_match_json,
+            input_str=input_label,
+            parameter_str=params_label,
+            usi=usi,
+            format_out_json=False,
+            compress_out_html=True,
+        )
 
     return matches_df
 

--- a/code/masst_tree.py
+++ b/code/masst_tree.py
@@ -151,11 +151,8 @@ def export_metadata_matches(
         metadata_df = pd.read_csv(metadata_file)
 
     # join on the file usi
-    results_df = pd.concat(
-        [matches_df.set_index("file_usi"), metadata_df.set_index("file_usi")],
-        axis=1,
-        join="inner",
-    ).reset_index()
+    # results_df = matches_df.merge(metadata_df, on="file_usi", how="inner")
+    results_df = pd.merge(matches_df, metadata_df, on="file_usi", how="inner")
 
     # export file with ncbi, matched_size,
     if len(results_df) > 0:

--- a/code/masst_utils.py
+++ b/code/masst_utils.py
@@ -6,6 +6,7 @@ from enum import Enum, auto
 import json
 import pandas as pd
 from dataclasses import dataclass
+from typing import Optional
 
 from pandas import DataFrame
 
@@ -25,6 +26,13 @@ class SpecialMasst:
     metadata_file: str
     tree_node_key: str
     metadata_key: str
+
+
+@dataclass
+class MasstMatchResults:
+    filtered_masst_df: Optional[DataFrame] = None
+    unfiltered_masst_df: Optional[DataFrame] = None
+    analog_masst_df: Optional[DataFrame] = None
 
 
 MICROBE_MASST = SpecialMasst(
@@ -277,12 +285,14 @@ def extract_matches_from_masst_results(
     analog,
     limit_to_best_match_in_file: bool = False,
     add_dataset_titles=False,
-) -> DataFrame | tuple[DataFrame, DataFrame, DataFrame] | DataFrame:
+) -> MasstMatchResults:
     """
     :param results_dict: masst results
     :param add_dataset_titles: add dataset titles to each row
-    :return: DataFrame of the individual matches
+    :return: MasstMatchResults of the individual matches
     """
+    match_results = MasstMatchResults()
+
     masst_df = pd.DataFrame(results_dict["results"])
     try:
         masst_df.drop(
@@ -299,54 +309,47 @@ def extract_matches_from_masst_results(
         )
     except Exception as e:
         # fastMASST response is sometimes empty
-        return masst_df
+        match_results.unfiltered_masst_df = masst_df
+        return match_results
 
-    original_masst_df = masst_df.copy()
-    masst_df = filter_matches(masst_df, precursor_mz_tol, min_matched_signals, analog)
+    # Unfiltered contains all the MASST match_results
+    unfiltered_masst_df = masst_df.copy()
+    # Filtered contains the matches that are within the precursor mass tolerance
+    filtered_masst_df = filter_matches(masst_df, precursor_mz_tol, min_matched_signals, analog)
+
+    # create an usi column that only points to the dataset:file (not scan)
+    unfiltered_masst_df["file_usi"] = unfiltered_masst_df["USI"].apply(usi_utils.ensure_simple_file_usi)
+    filtered_masst_df["file_usi"] = filtered_masst_df["USI"].apply(usi_utils.ensure_simple_file_usi)
+
     if add_dataset_titles:
         datasets = results_dict["grouped_by_dataset"]
         dataset_info_dict = dict([(e["Dataset"], e["title"]) for e in datasets])
         # might not be in the df
-        masst_df.drop(columns=["mzs", "intensities"], inplace=True, axis=1)
+        filtered_masst_df.drop(columns=["mzs", "intensities"], inplace=True, axis=1)
 
-        for match in masst_df:
+        for match in filtered_masst_df:
             match["dataset_title"] = dataset_info_dict.get(match["Dataset"], None)
 
+    if analog:
+        # for analog search we drop duplicates based on the rounded delta mass and file_usi
+        analog_masst_df = filtered_masst_df.copy()
+        analog_masst_df['rounded_delta'] = analog_masst_df['Delta Mass'].apply(lambda x: round(x, 0))
+        analog_masst_df = analog_masst_df.sort_values(
+            by=["Cosine", "Matching Peaks"], ascending=[False, False]
+        ).drop_duplicates(subset=['file_usi', 'rounded_delta'])
+        match_results.analog_masst_df = analog_masst_df
+
+    unfiltered_masst_df = unfiltered_masst_df.sort_values(
+        by=["Cosine", "Matching Peaks"], ascending=[False, False])
+
     if limit_to_best_match_in_file:
-        # create a usi column that only points to the dataset:file (not scan)
-        masst_df["file_usi"] = [
-            usi_utils.ensure_simple_file_usi(usi) for usi in masst_df["USI"]
-        ]
-        original_masst_df["file_usi"] = [
-            usi_utils.ensure_simple_file_usi(usi) for usi in original_masst_df["USI"]]
+        filtered_masst_df = filtered_masst_df.sort_values(
+            by=["Cosine", "Matching Peaks"], ascending=[False, False]
+        ).drop_duplicates("file_usi")
 
-        if analog:
-            # for analog search we drop duplicates based on the rounded delta mass and file_usi
-            analog_masst_df = masst_df.copy()
-            analog_masst_df['rounded_delta'] = analog_masst_df['Delta Mass'].apply(lambda x: round(x, 0))
-            analog_masst_df = analog_masst_df.sort_values(
-                by=["Cosine", "Matching Peaks"], ascending=[False, False]
-            ).drop_duplicates(subset=['file_usi', 'rounded_delta'])
-
-            # we want also to export the results as before (eliminating duplicates based only on file_usi)
-            masst_df = masst_df.sort_values(
-                by=["Cosine", "Matching Peaks"], ascending=[False, False]
-            ).drop_duplicates("file_usi")
-
-            # storing original FasstMASST results
-            original_masst_df = original_masst_df.sort_values(
-                by=["Cosine", "Matching Peaks"], ascending=[False, False])
-
-            return masst_df, analog_masst_df, original_masst_df
-
-        else:
-            # if not analog=True, return only the best match in file
-            masst_df = masst_df.sort_values(
-                by=["Cosine", "Matching Peaks"], ascending=[False, False]
-            ).drop_duplicates("file_usi")
-            return masst_df
-    else:
-        return masst_df
+    match_results.filtered_masst_df = filtered_masst_df
+    match_results.unfiltered_masst_df = unfiltered_masst_df
+    return match_results
 
 def extract_datasets_from_masst_results(
     results_dict, matches_df: pd.DataFrame


### PR DESCRIPTION
Due to the filter that happens in the limit_to_best_match_in_file (extract_matches_from_masst_results function), we were loosing many results if the analog search was turned ON. Example: if the molecule itself and some analogs were observed in the same file, we would many times just retrieve one analog, or only the molecule itself since it was filtering based on dataset/filename. The changes in this pull request now also create analog exports in which the condition for drop duplicates also consider the delta mass.