### PR TITLE
fix: update to use unfiltered_masst_df for library matches extraction

### DIFF
--- a/code/masst_client.py
+++ b/code/masst_client.py
@@ -77,7 +77,7 @@ def process_matches(
 
     lib_matches_df = masst.extract_matches_from_masst_results(
         library_matches, precursor_mz_tol, min_matched_signals, analog, False
-    ).filtered_masst_df
+    ).unfiltered_masst_df
 
     if len(lib_matches_df) > 0:
         lib_matches_df[LIB_COLUMNS].to_csv(


### PR DESCRIPTION
This PR updates the masst_client.py script to use `unfiltered_masst_df` instead of `filtered_masst_df` for extracting library matches.

This was causing issues when no library matches were retrieved.