### PR TITLE
add Delta Mass to dataset Matches table

### DIFF
--- a/code/internalized_tables.js
+++ b/code/internalized_tables.js
@@ -60,6 +60,7 @@ function getMatchedDatasets() {
                 entry["Interventions"] = node.Interventions ?? "";
                 entry["Cosine"] = match["Cosine"] ?? "";
                 entry["Matching signals"] = match["Matching Peaks"] ?? "";
+                entry["Delta Mass"] = match["Delta Mass"] ?? "";
                 entry["USI"] = match["USI"] ?? "";
                 entry["MassIVE"] = match["USI"].split(":")[1] ?? "";
                 entry["File"] = match["USI"].split(":scan:")[0] ?? "";

--- a/code/masst_tree.py
+++ b/code/masst_tree.py
@@ -163,7 +163,7 @@ def export_metadata_matches(
 def group_matches(special_masst: SpecialMasst, results_df) -> pd.DataFrame:
     grouped = results_df.groupby(special_masst.metadata_key)
     results_df = grouped.agg(matched_size=(special_masst.metadata_key, "size"))
-    results_df["matches_json"] = grouped[["USI", "Cosine", "Matching Peaks"]].apply(
+    results_df["matches_json"] = grouped[["USI", "Cosine", "Matching Peaks", "Delta Mass"]].apply(
         lambda x: x.to_json(orient="records")
     )
     return results_df.reset_index()


### PR DESCRIPTION
Here I'm adding the Delta Mass for the Dataset Matches table, so the interpretation of the results for the analog search will be more meaningful.

This basically modifies the .json file, so the tree will have the Delta Mass field to populate the table.

Please @robinschmid give me feedback so I can change anything, if necessary. Thanks!